### PR TITLE
Add writable operating-mode select (anti-thermosiphon)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Python bytecode / caches
 __pycache__/
 *.py[cod]
+
+# Local Home Assistant automation backups (operational, not part of the repo)
+.ha-automation-backup-*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Operating-mode select** (`select.warmlink_operating_mode`) — a writable Mode control exposing the confirmed-safe modes (*DHW only* = 0, *Heating + DHW* = 3). Enables the summer anti-thermosiphon trick: parking the 3-way diverter off the DHW tank (Mode = Heating + DHW) after a reheat breaks the passive convection loop that bleeds tank heat through the outdoor unit. Live-validated on real hardware: parking roughly halved the tank standby loss (~1.3 → ~0.67 °C/h) and decoupled the pipes toward room temperature. Unconfirmed modes are intentionally omitted to avoid accidentally selecting a cooling mode.
 - **Power on/off switch** (`switch.warmlink_power`) to control the heat pump from Home Assistant
 - **DHW summer control example** (`examples/automation_dhw_summer_control.yaml`) — power-cycles the pump in DHW-only mode without interrupting an active heating cycle
 - **DHW efficiency comparison example** (`examples/dhw_efficiency_comparison.yaml`) — logs daily DHW electricity per operating regime to compare deep-cycling vs. maintaining

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Monitor and control your WarmLink/Zealux heat pump directly from Home Assistant 
 ✅ **Real-time Updates** - Automatic updates every 2 minutes
 ✅ **Manual Refresh** - On-demand data refresh button
 ✅ **Power Control** - Turn the heat pump on/off from Home Assistant
+✅ **Operating-Mode Control** - Writable Mode select (DHW only / Heating + DHW) for seasonal control and the summer anti-thermosiphon trick
 ✅ **Multi-language** - Danish and English support
 ✅ **No Data Gaps** - Intelligent caching for continuous graphs
 ✅ **Async Operations** - Non-blocking file I/O for performance
@@ -123,6 +124,7 @@ sensor.warmlink_mode_state_modestate
 sensor.warmlink_high_pressure_switch_protection_e035
 button.warmlink_refresh_data
 switch.warmlink_power
+select.warmlink_operating_mode
 ...and 385 more!
 ```
 
@@ -211,6 +213,31 @@ target:
 > **Note:** `Power=0` is a *soft* off — the same as pressing Off in the app. The
 > firmware still runs its own graceful shutdown (pump-down / post-circulation).
 > It is **not** a hard power cut.
+
+### Operating-Mode Control
+
+```yaml
+# Park the 3-way diverter off the DHW tank (anti-thermosiphon)
+service: select.select_option
+target:
+  entity_id: select.warmlink_operating_mode
+data:
+  option: "Heating + DHW"
+```
+
+The Mode select exposes the two confirmed-safe modes: **DHW only** (`Mode=0`, the
+3-way valve sends flow to the tank) and **Heating + DHW** (`Mode=3`, the valve
+parks off the tank).
+
+> **Anti-thermosiphon use:** in summer, an idle DHW loop bleeds tank heat by
+> passive thermosiphon — the water pipes sit far above ambient while the unit is
+> off, slowly draining the tank through the cold outdoor unit. Writing
+> `Mode = Heating + DHW` *after* a reheat completes parks the diverter off the
+> tank and breaks that convection loop — a software "check valve." On real
+> hardware the diverter moves on the Mode write even with `Power=0`, and parking
+> roughly **halved** the measured standby loss (≈1.3 → ≈0.67 °C/h) while the
+> pipes cooled toward room temperature. Unconfirmed mode values are intentionally
+> not exposed, to avoid accidentally selecting a cooling mode.
 
 ### DHW Summer Control (Automated Power Cycling)
 
@@ -340,6 +367,7 @@ custom_components/warmlink/
 ├── __init__.py           # Integration setup
 ├── sensor.py             # Sensor platform
 ├── switch.py             # Switch platform (power on/off)
+├── select.py             # Select platform (operating mode)
 ├── button.py             # Button platform (refresh)
 ├── coordinator.py        # DataUpdateCoordinator
 ├── config_flow.py        # Configuration flow

--- a/custom_components/warmlink/__init__.py
+++ b/custom_components/warmlink/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor", "button", "switch"]
+PLATFORMS = ["sensor", "button", "switch", "select"]
 
 async def async_setup(hass, config):
     """Set up the WarmLink component."""

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "70.0",
+  "version": "71.0",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/select.py
+++ b/custom_components/warmlink/select.py
@@ -1,0 +1,125 @@
+"""Select platform for WarmLink integration.
+
+Exposes the heat pump's operating Mode as a writable ``select`` entity so it can
+be driven from Home Assistant automations. The main use case is the summer
+anti-thermosiphon trick: parking the 3-way diverter off the DHW tank by writing
+``Mode = Heating + DHW`` after a reheat completes breaks the passive convection
+loop that otherwise bleeds tank heat out through the (cold) outdoor unit.
+
+Only the modes we have *confirmed* on real hardware are exposed, on purpose:
+writing an unconfirmed Mode value risks selecting a cooling mode. Add more
+options here once they are calibrated against the unit's own panel.
+"""
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+# Control code for the operating mode (same protocolCode used by the
+# linked-go/AquaTemp control endpoint and read back on the Mode sensor).
+MODE_CODE = "Mode"
+
+# Confirmed-safe modes only (label -> raw protocol value).
+#   0 = DHW only        -> 3-way valve to the tank
+#   3 = Heating + DHW   -> valve parks off the tank (the anti-siphon position)
+# 1/2/4/5... are NOT confirmed (possible cooling) and are deliberately omitted.
+MODE_OPTIONS = {
+    "DHW only": "0",
+    "Heating + DHW": "3",
+}
+VALUE_TO_LABEL = {v: k for k, v in MODE_OPTIONS.items()}
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up WarmLink select entities."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([WarmlinkModeSelect(coordinator, entry)])
+    LOGGER.info("WarmLink: Added operating mode select")
+
+
+class WarmlinkModeSelect(CoordinatorEntity, SelectEntity):
+    """Writable operating-mode selector (Mode code)."""
+
+    def __init__(self, coordinator, entry):
+        """Initialize the select."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_mode_select"
+        self._attr_name = "Operating Mode"
+        self._attr_icon = "mdi:water-boiler"
+        self._attr_options = list(MODE_OPTIONS.keys())
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the sensors/switch/button device)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _mode_value(self):
+        """Return the raw value of the Mode code, or None if unavailable."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == MODE_CODE:
+                    return item.get("value")
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Available as long as the coordinator has data."""
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def current_option(self):
+        """Return the current mode label.
+
+        Returns ``None`` if the unit reports a mode we have not confirmed, so
+        the UI shows "unknown" rather than misrepresenting an unverified value.
+        """
+        value = self._mode_value()
+        if value in (None, "", "null"):
+            return None
+        return VALUE_TO_LABEL.get(str(value).strip())
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the selected mode to the device."""
+        value = MODE_OPTIONS.get(option)
+        if value is None:
+            LOGGER.error("WarmLink: Unknown mode option %s", option)
+            return
+
+        device_code = None
+        if self.coordinator.device_info:
+            device_code = self.coordinator.device_info.get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot set mode")
+            return
+
+        LOGGER.info("WarmLink: Requesting Mode=%s (%s)", value, option)
+        resp = await self.coordinator.api.set_value(device_code, MODE_CODE, value)
+        LOGGER.info("WarmLink: Mode=%s command response: %s", value, resp)
+        # Refresh so the select reflects the new state from the API.
+        await self.coordinator.async_request_refresh()


### PR DESCRIPTION
## What

Adds a writable **`select.warmlink_operating_mode`** entity exposing the heat pump's `Mode` so Home Assistant automations can drive it. Only the two **confirmed-safe** modes are offered:

- **DHW only** (`Mode=0`) — 3-way valve to the tank
- **Heating + DHW** (`Mode=3`) — valve parks off the tank

Unconfirmed mode values (1/2/4/5…) are deliberately omitted to avoid accidentally selecting a cooling mode; they can be added once calibrated.

## Why — summer anti-thermosiphon

In summer an idle DHW loop bleeds tank heat by passive **thermosiphon**: the water pipes sit ~25 °C above ambient while the unit is off, slowly draining the tank through the cold outdoor unit. Writing `Mode = Heating + DHW` *after* a reheat parks the diverter off the tank and breaks that convection loop — a software "check valve."

**Live-validated on real hardware** (90-min A/B, Power=0 throughout):
- Parked (Mode=3): pipe inlet fell 44.9 → 32.6 °C toward room temp; tank standby loss roughly **halved** (~1.3 → ~0.67 °C/h).
- Not parked (Mode=0): pipes stayed hot, siphon active.

The diverter moves on the Mode write even with `Power=0`, so no compressor/pump run is needed to park it.

## Changes
- `select.py` — new platform, modeled on `switch.py` (CoordinatorEntity; reads `Mode` from coordinator data, writes via `api.set_value`, refreshes after).
- `__init__.py` — register the `select` platform.
- `manifest.json` — `70.0` → `71.0`.
- `README.md` / `CHANGELOG.md` — document the control + anti-thermosiphon use.
- `.gitignore` — ignore local `.ha-automation-backup-*/` dirs.

## Notes / follow-up
- Mode-write telemetry has a ~2 min cloud-poll lag (diverter likely moves promptly; the read-back lags) — relevant for automation timing.
- Next: an HA automation that, gated on a summer-mode toggle, parks (Mode=3) after each reheat and unparks (Mode=0) before the next, then a week-long energy comparison. Timing to be fine-tuned once DS18B20 pipe sensors are mounted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)