### PR TITLE
docs: English example labels + install/upgrade guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,14 +133,14 @@ button.warmlink_refresh_data
 
 ```yaml
 type: entities
-title: Varmepumpe Temperaturer
+title: Heat Pump Temperatures
 entities:
   - entity: sensor.warmlink_water_inlet_temp_t01
-    name: Indløb
+    name: Inlet
   - entity: sensor.warmlink_water_outlet_temp_t02
-    name: Udløb
+    name: Outlet
   - entity: sensor.warmlink_ambient_temp_t04
-    name: Udetemperatur
+    name: Ambient
 ```
 
 ### Manual Refresh Button
@@ -148,7 +148,7 @@ entities:
 ```yaml
 type: button
 entity: button.warmlink_refresh_data
-name: Opdater Nu
+name: Refresh Now
 icon: mdi:refresh
 tap_action:
   action: call-service
@@ -161,7 +161,7 @@ tap_action:
 
 ```yaml
 automation:
-  - alias: "Alarm Ved E035 Fejl"
+  - alias: "Alert on E035 fault"
     trigger:
       - platform: state
         entity_id: sensor.warmlink_high_pressure_switch_protection_e035
@@ -169,8 +169,8 @@ automation:
     action:
       - service: notify.mobile_app
         data:
-          title: "⚠️ Varmepumpe Alarm!"
-          message: "E035 Højtrykskontakt beskyttelse aktiveret!"
+          title: "⚠️ Heat Pump Alert!"
+          message: "E035 high-pressure switch protection triggered!"
           data:
             priority: high
 ```
@@ -180,7 +180,7 @@ automation:
 ```yaml
 template:
   - sensor:
-      - name: "Varmepumpe COP"
+      - name: "Heat Pump COP"
         unique_id: warmlink_cop
         unit_of_measurement: ""
         state_class: measurement

--- a/RELEASE_NOTES_v71.md
+++ b/RELEASE_NOTES_v71.md
@@ -31,9 +31,24 @@ The integration can now **set** values, not just read them. This release adds Po
 
 ---
 
-## ⬆️ Upgrade
-- Smooth file replacement + restart. **No entity-ID migration** (unlike v70).
-- The new switch and select entities appear automatically after a restart.
+## 📦 Installation & Upgrade
+
+### New install — HACS (recommended)
+1. HACS → ⋮ (top right) → **Custom repositories** → add `https://github.com/srbjessen/ha-warmlink`, category **Integration**.
+2. Install **WarmLink**, then **restart Home Assistant**.
+3. **Settings → Devices & Services → + Add Integration → WarmLink**; enter your WarmLink/Zealux account email, password, and language (`da` or `en`).
+
+### New install — manual
+1. Download the source from the [v71.0 release](https://github.com/srbjessen/ha-warmlink/releases/tag/v71.0).
+2. Copy `custom_components/warmlink` into your Home Assistant `config/custom_components/` directory.
+3. Restart Home Assistant, then add the integration as above.
+
+### Upgrading from v63–v70
+- **HACS:** open the WarmLink card → **Update** to v71.0 → **restart Home Assistant**.
+- **Manual:** replace the `custom_components/warmlink` folder with v71.0 → restart.
+- **No entity-ID migration and no config changes** — v71.0 is purely additive. Existing sensors, dashboards, and automations keep working; the new `switch.warmlink_power` and the two `select` entities appear on the WarmLink device after the restart.
+
+> Coming straight from **v70**? That was the breaking entity-ID release. If you skipped it, do the v70 entity-ID migration first (see the v70 notes), then v71.0 layers cleanly on top.
 
 ---
 


### PR DESCRIPTION
Follow-up doc cleanup after the v71.0 release.

- **README:** translate the remaining Danish example labels (temperature dashboard card, refresh button, fault-code automation, COP sensor) to English, so the public docs read consistently in English.
- **RELEASE_NOTES_v71.md:** expand the brief Upgrade note into a full **Installation & Upgrade** guide — HACS and manual paths for a new install, plus upgrade steps from v63–v70 (no entity migration; purely additive).

Docs-only; no code changes.