### PR TITLE
v72.0: support shared / member accounts (Device code)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [72.0] - 2026-06-25
+
+### Fixed
+- **Shared / "member" accounts can now be set up** — added an optional **Device code** field to the config flow. WarmLink member accounts receive an empty device list from the cloud, so auto-detection failed and setup never completed; supplying the device code lets the integration address the heat pump directly. Login and device access are validated during setup with clear error messages. Resolves #1.
+
 ## [71.0] - 2026-06-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [72.0] - 2026-06-25
 
+### Added
+- **Reconfigure support** — change the account or device code on an existing install (the WarmLink entry → **Reconfigure**) without removing and re-adding it. The same config entry is updated in place, so all entities, their IDs, and any dashboard/automation references are preserved.
+
 ### Fixed
 - **Shared / "member" accounts can now be set up** — added an optional **Device code** field to the config flow. WarmLink member accounts receive an empty device list from the cloud, so auto-detection failed and setup never completed; supplying the device code lets the integration address the heat pump directly. Login and device access are validated during setup with clear error messages. Resolves #1.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,14 @@ Monitor and control your WarmLink/Zealux heat pump directly from Home Assistant 
    - **Email**: Your WarmLink account email
    - **Password**: Your WarmLink account password
    - **Language**: `da` (Danish) or `en` (English)
+   - **Device code** *(optional)*: leave blank to auto-detect. Required for **shared / "member" accounts** — see below.
 5. Click **Submit**
+
+#### Shared / "member" accounts
+
+WarmLink allows only one concurrent login per account, so a common setup is to keep your main (owner) account for the app and add a **second account as a "member"** of the home for Home Assistant. Member accounts receive an **empty device list** from the WarmLink cloud, so auto-detection can't find the heat pump and setup fails.
+
+To use a member account, fill in the **Device code**: open the WarmLink app → your heat pump → device information, and copy the device code (the module's long numeric ID). With it filled in, the integration talks to the device directly and works on member accounts.
 
 ### Entities
 

--- a/RELEASE_NOTES_v72.md
+++ b/RELEASE_NOTES_v72.md
@@ -1,0 +1,25 @@
+# WarmLink v72.0 - Member-Account Support
+
+## 🐛 Fixed — Shared / "Member" Accounts
+
+WarmLink allows only one concurrent login per account, so many people keep their main (owner) account for the app and add a **second account as a "member"** of the home for Home Assistant. Until now that failed: member accounts receive an **empty device list** from the WarmLink cloud, so the integration couldn't find the heat pump and setup never completed (issue #1).
+
+**Fix:** the config flow now has an optional **Device code** field.
+- **Owner accounts** — leave it blank; the device is auto-detected as before.
+- **Member / shared accounts** — enter the heat pump's device code (find it in the WarmLink app → device information). The integration then talks to the device directly.
+
+Login and device access are also validated during setup now, so wrong credentials or a wrong device code give a clear error instead of a silent failure.
+
+**Resolves #1.**
+
+---
+
+## ⬆️ Upgrade
+- **HACS:** update to v72.0 → restart Home Assistant. **Manual:** replace the `custom_components/warmlink` folder → restart.
+- **No changes needed for existing setups** — the Device code field is optional and defaults to blank (auto-detect). Owner accounts are unaffected.
+- **Member-account users:** after updating, remove and re-add the integration with the Device code filled in.
+
+---
+
+## Resolves
+- #1 — "Integration does not work with 'member' accounts"

--- a/RELEASE_NOTES_v72.md
+++ b/RELEASE_NOTES_v72.md
@@ -14,10 +14,16 @@ Login and device access are also validated during setup now, so wrong credential
 
 ---
 
+## ✨ Added — Reconfigure (no starting over)
+
+Changed account, or want to add the device code to an install you already have? Use **Reconfigure** on the WarmLink entry (its ⋮ menu → *Reconfigure*) to update the username, password, or device code **in place**. The same config entry is kept, so all your entities, their IDs, and any dashboard/automation references are preserved — no removing and re-adding.
+
+---
+
 ## ⬆️ Upgrade
 - **HACS:** update to v72.0 → restart Home Assistant. **Manual:** replace the `custom_components/warmlink` folder → restart.
-- **No changes needed for existing setups** — the Device code field is optional and defaults to blank (auto-detect). Owner accounts are unaffected.
-- **Member-account users:** after updating, remove and re-add the integration with the Device code filled in.
+- **Not a breaking change** — the Device code field is optional and defaults to blank (auto-detect). Existing owner setups are unaffected; no entity changes, no migration.
+- **Member-account users:** after updating, open **Reconfigure** on the WarmLink entry and fill in the Device code — your entities are kept (no need to remove and re-add).
 
 ---
 

--- a/custom_components/warmlink/config_flow.py
+++ b/custom_components/warmlink/config_flow.py
@@ -21,30 +21,36 @@ DATA_SCHEMA = vol.Schema({
 })
 
 
+async def _validate(hass, user_input):
+    """Validate credentials + device access. Returns an errors dict ({} = OK).
+
+    Normalises ``device_code`` in place. A blank device_code means "auto-detect"
+    (owner accounts); members/shared accounts get an empty device list from the
+    cloud and must supply the code explicitly — see issue #1.
+    """
+    errors = {}
+    device_code = (user_input.get("device_code") or "").strip()
+    user_input["device_code"] = device_code
+
+    api = WarmlinkAPI(user_input["username"], user_input["password"], hass)
+    if not await api.login():
+        errors["base"] = "auth"
+    elif device_code:
+        resp = await api.get_props_batch(device_code, ["Power", "Mode"])
+        if not resp or not resp.get("objectResult"):
+            errors["device_code"] = "device_not_found"
+    else:
+        devs = await api.get_devices()
+        if not devs or not devs.get("objectResult"):
+            errors["base"] = "no_devices"
+    return errors
+
+
 class WarmlinkConfigFlow(config_entries.ConfigFlow, domain="warmlink"):
     async def async_step_user(self, user_input=None):
         errors = {}
         if user_input is not None:
-            # A blank device_code means "auto-detect" (works for owner accounts).
-            # Members/shared accounts get an empty device list from the cloud, so
-            # they must supply the device code explicitly — see issue #1.
-            device_code = (user_input.get("device_code") or "").strip()
-            user_input["device_code"] = device_code
-
-            api = WarmlinkAPI(user_input["username"], user_input["password"], self.hass)
-            if not await api.login():
-                errors["base"] = "auth"
-            elif device_code:
-                # Verify the supplied device answers for this account.
-                resp = await api.get_props_batch(device_code, ["Power", "Mode"])
-                if not resp or not resp.get("objectResult"):
-                    errors["device_code"] = "device_not_found"
-            else:
-                # Owner accounts: auto-discover via the device list.
-                devs = await api.get_devices()
-                if not devs or not devs.get("objectResult"):
-                    errors["base"] = "no_devices"
-
+            errors = await _validate(self.hass, user_input)
             if not errors:
                 return self.async_create_entry(title="WarmLink", data=user_input)
 
@@ -52,6 +58,30 @@ class WarmlinkConfigFlow(config_entries.ConfigFlow, domain="warmlink"):
             step_id="user",
             data_schema=self.add_suggested_values_to_schema(
                 DATA_SCHEMA, user_input or {}
+            ),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(self, user_input=None):
+        """Change the account / device code on an existing entry.
+
+        Updates the same config entry in place, so the entry_id — and therefore
+        every entity ID and dashboard/automation reference — is preserved. No
+        need to remove and re-add the integration.
+        """
+        errors = {}
+        entry = self.hass.config_entries.async_get_entry(self.context["entry_id"])
+        if user_input is not None:
+            errors = await _validate(self.hass, user_input)
+            if not errors:
+                self.hass.config_entries.async_update_entry(entry, data=user_input)
+                await self.hass.config_entries.async_reload(entry.entry_id)
+                return self.async_abort(reason="reconfigure_successful")
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=self.add_suggested_values_to_schema(
+                DATA_SCHEMA, user_input or (entry.data if entry else {})
             ),
             errors=errors,
         )

--- a/custom_components/warmlink/config_flow.py
+++ b/custom_components/warmlink/config_flow.py
@@ -1,18 +1,57 @@
 
+import logging
+
 from homeassistant import config_entries
 import voluptuous as vol
+
+from .managers.warmlink_api import WarmlinkAPI
+
+LOGGER = logging.getLogger(__name__)
 
 LANGUAGES = {
     "en": "English",
     "da": "Dansk"
 }
 
+DATA_SCHEMA = vol.Schema({
+    vol.Required("username"): str,
+    vol.Required("password"): str,
+    vol.Required("language", default="en"): vol.In(LANGUAGES),
+    vol.Optional("device_code", default=""): str,
+})
+
+
 class WarmlinkConfigFlow(config_entries.ConfigFlow, domain="warmlink"):
     async def async_step_user(self, user_input=None):
-        if user_input:
-            return self.async_create_entry(title="WarmLink", data=user_input)
-        return self.async_show_form(step_id="user", data_schema=vol.Schema({
-            vol.Required("username"): str,
-            vol.Required("password"): str,
-            vol.Required("language", default="en"): vol.In(LANGUAGES)
-        }))
+        errors = {}
+        if user_input is not None:
+            # A blank device_code means "auto-detect" (works for owner accounts).
+            # Members/shared accounts get an empty device list from the cloud, so
+            # they must supply the device code explicitly — see issue #1.
+            device_code = (user_input.get("device_code") or "").strip()
+            user_input["device_code"] = device_code
+
+            api = WarmlinkAPI(user_input["username"], user_input["password"], self.hass)
+            if not await api.login():
+                errors["base"] = "auth"
+            elif device_code:
+                # Verify the supplied device answers for this account.
+                resp = await api.get_props_batch(device_code, ["Power", "Mode"])
+                if not resp or not resp.get("objectResult"):
+                    errors["device_code"] = "device_not_found"
+            else:
+                # Owner accounts: auto-discover via the device list.
+                devs = await api.get_devices()
+                if not devs or not devs.get("objectResult"):
+                    errors["base"] = "no_devices"
+
+            if not errors:
+                return self.async_create_entry(title="WarmLink", data=user_input)
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=self.add_suggested_values_to_schema(
+                DATA_SCHEMA, user_input or {}
+            ),
+            errors=errors,
+        )

--- a/custom_components/warmlink/coordinator.py
+++ b/custom_components/warmlink/coordinator.py
@@ -26,8 +26,20 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
         self.entry = entry
         self.api = WarmlinkAPI(entry.data["username"], entry.data["password"], hass)
         self.codes = _CODES
-        self.device_info = None
-        self._device_code = None
+        # A device_code in the config entry means the user supplied it manually
+        # (members/shared accounts, whose cloud device list comes back empty —
+        # see issue #1). Use it directly and skip auto-discovery.
+        manual_code = (entry.data.get("device_code") or "").strip()
+        self._device_code = manual_code or None
+        self.device_info = {
+            "device_code": self._device_code,
+            "device_nick_name": None,
+            "product_id": None,
+            "device_id": None,
+            "cust_model": None,
+            "model": None,
+            "sn": None,
+        } if self._device_code else None
         self._logged_unknown_codes = set()  # Track unknown codes we've already logged
         self._logged_missing_codes = set()  # Track missing codes we've already logged
         super().__init__(
@@ -49,7 +61,11 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
                 
                 if not devs or "objectResult" not in devs or not devs["objectResult"]:
                     LOGGER.error("WarmLink: No devices returned from API")
-                    raise UpdateFailed("No devices returned from API")
+                    raise UpdateFailed(
+                        "No devices returned from API. If this is a shared/member "
+                        "WarmLink account, remove the integration and add it again "
+                        "with the Device Code filled in (find it in the WarmLink app)."
+                    )
                 device = devs["objectResult"][0]
                 
                 # Cache device info

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "71.0",
+  "version": "72.0",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/translations/da.json
+++ b/custom_components/warmlink/translations/da.json
@@ -7,9 +7,18 @@
         "data": {
           "username": "Brugernavn",
           "password": "Adgangskode",
-          "language": "Sprog"
+          "language": "Sprog",
+          "device_code": "Enhedskode (kun ved medlems-/delte konti)"
+        },
+        "data_description": {
+          "device_code": "Lad stå tomt for auto-detektion (ejer-konti). For en delt/medlems-konto: indtast varmepumpens enhedskode — find den i WarmLink-appen under enhedens oplysninger."
         }
       }
+    },
+    "error": {
+      "auth": "Login mislykkedes. Tjek brugernavn og adgangskode.",
+      "no_devices": "Ingen enhed fundet på kontoen. Hvis dette er en delt/medlems-konto, indtast enhedskoden nedenfor.",
+      "device_not_found": "Den enhedskode returnerede ingen data for kontoen. Tjek den i WarmLink-appen."
     }
   }
 }

--- a/custom_components/warmlink/translations/da.json
+++ b/custom_components/warmlink/translations/da.json
@@ -13,12 +13,28 @@
         "data_description": {
           "device_code": "Lad stå tomt for auto-detektion (ejer-konti). For en delt/medlems-konto: indtast varmepumpens enhedskode — find den i WarmLink-appen under enhedens oplysninger."
         }
+      },
+      "reconfigure": {
+        "title": "Omkonfigurér WarmLink",
+        "description": "Skift konto eller enhedskode. Dine entiteter og deres ID'er bevares.",
+        "data": {
+          "username": "Brugernavn",
+          "password": "Adgangskode",
+          "language": "Sprog",
+          "device_code": "Enhedskode (kun ved medlems-/delte konti)"
+        },
+        "data_description": {
+          "device_code": "Lad stå tomt for auto-detektion (ejer-konti). For en delt/medlems-konto: indtast varmepumpens enhedskode — find den i WarmLink-appen under enhedens oplysninger."
+        }
       }
     },
     "error": {
       "auth": "Login mislykkedes. Tjek brugernavn og adgangskode.",
       "no_devices": "Ingen enhed fundet på kontoen. Hvis dette er en delt/medlems-konto, indtast enhedskoden nedenfor.",
       "device_not_found": "Den enhedskode returnerede ingen data for kontoen. Tjek den i WarmLink-appen."
+    },
+    "abort": {
+      "reconfigure_successful": "Omkonfigurationen lykkedes."
     }
   }
 }

--- a/custom_components/warmlink/translations/en.json
+++ b/custom_components/warmlink/translations/en.json
@@ -7,9 +7,18 @@
         "data": {
           "username": "Username",
           "password": "Password",
-          "language": "Language"
+          "language": "Language",
+          "device_code": "Device code (members / shared accounts only)"
+        },
+        "data_description": {
+          "device_code": "Leave blank to auto-detect (owner accounts). For a shared/member account, enter the heat pump's device code — find it in the WarmLink app under the device's information."
         }
       }
+    },
+    "error": {
+      "auth": "Login failed. Check your username and password.",
+      "no_devices": "No device was found on this account. If this is a shared/member account, enter the device code below.",
+      "device_not_found": "That device code returned no data for this account. Double-check it in the WarmLink app."
     }
   }
 }

--- a/custom_components/warmlink/translations/en.json
+++ b/custom_components/warmlink/translations/en.json
@@ -13,12 +13,28 @@
         "data_description": {
           "device_code": "Leave blank to auto-detect (owner accounts). For a shared/member account, enter the heat pump's device code — find it in the WarmLink app under the device's information."
         }
+      },
+      "reconfigure": {
+        "title": "Reconfigure WarmLink",
+        "description": "Change the account or device code. Your entities and their IDs are kept.",
+        "data": {
+          "username": "Username",
+          "password": "Password",
+          "language": "Language",
+          "device_code": "Device code (members / shared accounts only)"
+        },
+        "data_description": {
+          "device_code": "Leave blank to auto-detect (owner accounts). For a shared/member account, enter the heat pump's device code — find it in the WarmLink app under the device's information."
+        }
       }
     },
     "error": {
       "auth": "Login failed. Check your username and password.",
       "no_devices": "No device was found on this account. If this is a shared/member account, enter the device code below.",
       "device_not_found": "That device code returned no data for this account. Double-check it in the WarmLink app."
+    },
+    "abort": {
+      "reconfigure_successful": "Re-configuration was successful."
     }
   }
 }


### PR DESCRIPTION
Resolves #1 — the integration failed for WarmLink "member" (shared) accounts.

## Cause
Member accounts receive an **empty device list** from the WarmLink cloud, but the coordinator hard-requires the device list to return a device, so setup never completed.

## Fix
- Add an optional **Device code** field to the config flow. Blank = auto-detect (owner accounts, unchanged); filled = address the heat pump directly (members).
- The coordinator uses the manual device code and skips list-based discovery.
- Login and device access are validated at setup, with clear errors.
- README documents the member-account setup; manifest bumped to 72.0.

## Testing
Verified live against a real member account: the device list comes back empty, but `getDataByCode` with the device code returns live data (Power, Mode, T01, T08, R01). Owner-account auto-detection is unchanged.

Not a breaking change — the field is optional and defaults to blank.