### PR TITLE
v73.0: DHW target range follows the device's own min/max

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [73.0] - 2026-06-25
+
+### Changed
+- **DHW target range now follows the device's own min/max** (registers `R36`/`R37`) instead of a fixed 47–60 °C — read live, so the dropdown matches each unit's configured range (e.g. 15–55 °C on some models) and tracks changes made in the WarmLink app. Selecting a value validates against the live range. Addresses the range feedback in #9. ⚠️ Running the tank low for price/solar optimisation is useful, but a tank sitting ~32–45 °C is where Legionella grows fastest — keep a weekly disinfection cycle to ≥60 °C on if you do (see the release notes).
+
 ## [72.0] - 2026-06-25
 
 ### Added

--- a/RELEASE_NOTES_v73.md
+++ b/RELEASE_NOTES_v73.md
@@ -1,0 +1,27 @@
+# WarmLink v73.0 - Device-Driven DHW Range
+
+## 🔧 Changed — DHW target range now follows your unit
+
+The DHW target dropdown previously used a fixed **47–60 °C** band. It now reads the device's **own min/max** (registers `R36`/`R37`) **live**, so:
+- You get your unit's actual configured range (e.g. **15–55 °C** on some models, 47–60 on others).
+- If you change the limits in the WarmLink app, the dropdown follows on the next update.
+
+Thanks to @ferrystienstra-cloud for the suggestion (#9).
+
+---
+
+## ⚠️ A note on low DHW temperatures (Legionella)
+
+Setting the tank low (e.g. ~35 °C) for price or solar-surplus optimisation is genuinely useful — but a tank sitting around **32–45 °C is exactly where Legionella grows fastest**. General guidance (WHO/HSE) is to store hot water at **≥60 °C**, or — if you run it cooler for efficiency — to run a **weekly anti-Legionella cycle that heats the whole tank to ≥60 °C** (most WarmLink/Zealux units have this built in).
+
+For reference: at 60 °C Legionella is ~killed in 30 minutes; at 55 °C a full kill takes 5–6 hours. So if you run the tank low, keep the weekly disinfection cycle on.
+
+---
+
+## ⬆️ Upgrade
+- **HACS:** update to v73.0 → restart. **Manual:** replace the `custom_components/warmlink` folder → restart.
+- **Not a breaking change** — same DHW target select, just an automatic/wider range from your device.
+
+---
+
+☕ *Enjoying WarmLink? It's free and maintained in my spare time — [a coffee](https://ko-fi.com/srbjessen) is a lovely thank-you.*

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "72.0",
+  "version": "73.0",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/select.py
+++ b/custom_components/warmlink/select.py
@@ -134,10 +134,14 @@ class WarmlinkModeSelect(CoordinatorEntity, SelectEntity):
 
 
 # DHW target temperature as a discrete °C dropdown (writes the R01 code).
-# The device's DHW target range is R36..R37 = 47..60 °C.
+# The selectable range is read live from the device's own min/max registers
+# (R36 = min, R37 = max), so it matches each unit's configured range and tracks
+# changes made in the WarmLink app. Falls back to 47..60 if not reported.
 DHW_TARGET_CODE = "R01"
-DHW_MIN = 47
-DHW_MAX = 60
+DHW_MIN_CODE = "R36"
+DHW_MAX_CODE = "R37"
+DEFAULT_MIN = 47
+DEFAULT_MAX = 60
 
 
 class WarmlinkDHWTargetSelect(CoordinatorEntity, SelectEntity):
@@ -155,7 +159,7 @@ class WarmlinkDHWTargetSelect(CoordinatorEntity, SelectEntity):
         self._attr_unique_id = f"{entry.entry_id}_dhw_target_select"
         self._attr_name = "DHW Target Temperature"
         self._attr_icon = "mdi:thermometer-water"
-        self._attr_options = [str(t) for t in range(DHW_MIN, DHW_MAX + 1)]
+        # options are computed dynamically from the device range (see `options`)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -182,13 +186,38 @@ class WarmlinkDHWTargetSelect(CoordinatorEntity, SelectEntity):
             model=device_model,
         )
 
-    def _r01_value(self):
-        """Return the raw R01 value, or None if unavailable."""
+    def _code_value(self, code):
+        """Return the raw value of a protocol code, or None if unavailable."""
         if self.coordinator.data:
             for item in self.coordinator.data:
-                if item.get("code") == DHW_TARGET_CODE:
+                if item.get("code") == code:
                     return item.get("value")
         return None
+
+    def _range(self):
+        """Return (min, max) °C from the device's R36/R37, else the defaults."""
+        lo, hi = DEFAULT_MIN, DEFAULT_MAX
+        try:
+            v = self._code_value(DHW_MIN_CODE)
+            if v not in (None, "", "null"):
+                lo = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        try:
+            v = self._code_value(DHW_MAX_CODE)
+            if v not in (None, "", "null"):
+                hi = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        if lo > hi:  # guard against an implausible / partial report
+            lo, hi = DEFAULT_MIN, DEFAULT_MAX
+        return lo, hi
+
+    @property
+    def options(self):
+        """Whole-degree options across the device's reported range (live)."""
+        lo, hi = self._range()
+        return [str(t) for t in range(lo, hi + 1)]
 
     @property
     def available(self) -> bool:
@@ -198,21 +227,25 @@ class WarmlinkDHWTargetSelect(CoordinatorEntity, SelectEntity):
     @property
     def current_option(self):
         """Return the current DHW target as a dropdown option (rounded to °C)."""
-        value = self._r01_value()
+        value = self._code_value(DHW_TARGET_CODE)
         if value in (None, "", "null"):
             return None
         try:
             opt = str(int(round(float(value))))
         except (TypeError, ValueError):
             return None
-        return opt if opt in self._attr_options else None
+        return opt if opt in self.options else None
 
     async def async_select_option(self, option: str) -> None:
         """Write the chosen DHW target temperature to the device."""
         try:
-            target = int(option)
+            target = int(round(float(option)))
         except (ValueError, TypeError):
             LOGGER.error("WarmLink: Unrecognised DHW target option %s", option)
+            return
+        if str(target) not in self.options:
+            lo, hi = self._range()
+            LOGGER.error("WarmLink: DHW target %s out of device range %s-%s", target, lo, hi)
             return
 
         device_code = None


### PR DESCRIPTION
Follow-up to #9 feedback (@ferrystienstra-cloud): the DHW target dropdown used a fixed 47–60 °C band. It now reads the device's own min/max (R36/R37) live, so each unit gets its actual configured range (e.g. 15–55 °C) and the dropdown tracks changes made in the WarmLink app. Selecting a value validates against the live range. Includes a Legionella note in the release notes for users running low DHW temps. Verified on hardware (47–60 from R36=47/R37=60; select 54→R01 54). Not breaking.