### PR TITLE
Add cooling modes, cooling/heating targets, climate & water_heater entities

### DIFF
--- a/custom_components/warmlink/__init__.py
+++ b/custom_components/warmlink/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor", "button", "switch", "select"]
+PLATFORMS = ["sensor", "button", "switch", "select", "water_heater", "climate"]
 
 async def async_setup(hass, config):
     """Set up the WarmLink component."""

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -1,0 +1,253 @@
+"""Climate platform for WarmLink integration.
+
+Wraps the *space-conditioning* side of the heat pump (heating and cooling) as a
+single Home Assistant ``climate`` entity, so it renders as a thermostat card:
+
+  hvac_mode OFF   -> heat pump Power off
+  hvac_mode HEAT  -> Power on + Mode = Heating (1);  target writes Heating Target (R02)
+  hvac_mode COOL  -> Power on + Mode = Cooling (2);  target writes Cooling Target (R03)
+
+  current_temperature = Outlet Water Temp (T02) — the process temperature the unit
+                        actually regulates for space heating/cooling.
+
+Notes / scope:
+- This entity governs *space conditioning* only. Domestic hot water has its own
+  ``water_heater`` entity (DHW setpoint R01). The combined "+ DHW" operating modes
+  (3/4) are read back as HEAT/COOL here; to explicitly select a "+ DHW" combo, use
+  the Operating Mode select.
+- Setting a temperature while OFF is ignored (no active heating/cooling target).
+- Changing hvac_mode writes the whole-unit Power switch, which will also trigger any
+  automations bound to it (e.g. the underfloor-pump sync).
+"""
+import logging
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+POWER_CODE = "Power"
+MODE_CODE = "Mode"
+OUTLET_TEMP_CODE = "T02"
+
+HEAT_TARGET_CODE = "R02"
+HEAT_MIN_CODE = "R10"
+HEAT_MAX_CODE = "R11"
+COOL_TARGET_CODE = "R03"
+COOL_MIN_CODE = "R08"
+COOL_MAX_CODE = "R09"
+
+# Raw Mode values (confirmed on hardware, see select.py).
+MODE_HEATING = "1"
+MODE_COOLING = "2"
+HEATING_MODES = {"1", "3"}   # Heating, Heating + DHW
+COOLING_MODES = {"2", "4"}   # Cooling, Cooling + DHW
+
+DEFAULT_HEAT_MIN, DEFAULT_HEAT_MAX = 20, 60
+DEFAULT_COOL_MIN, DEFAULT_COOL_MAX = 7, 30
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the WarmLink space-conditioning climate entity."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([WarmlinkClimate(coordinator, entry)])
+    LOGGER.info("WarmLink: Added space-conditioning climate entity")
+
+
+class WarmlinkClimate(CoordinatorEntity, ClimateEntity):
+    """Space heating/cooling as a climate entity (Power + Mode + R02/R03)."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.OFF, HVACMode.HEAT, HVACMode.COOL]
+    _attr_target_temperature_step = 1
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+    # We implement async_turn_on/off ourselves; opt out of the legacy shim.
+    _enable_turn_on_off_backwards_compatibility = False
+
+    def __init__(self, coordinator, entry):
+        """Initialize the climate entity."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_climate"
+        self._attr_name = "Space Conditioning"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the other WarmLink entities)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    # -- helpers --------------------------------------------------------------
+    def _raw(self, code):
+        """Return a protocol code's raw value (string), or None."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    v = item.get("value")
+                    return None if v in (None, "", "null") else str(v).strip()
+        return None
+
+    def _num(self, code):
+        """Return a protocol code's value as float, or None."""
+        v = self._raw(code)
+        if v is None:
+            return None
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    def _is_on(self):
+        """True if the heat pump Power reads on."""
+        v = self._raw(POWER_CODE)
+        return v is not None and v not in ("0", "0.0")
+
+    # -- state ----------------------------------------------------------------
+    @property
+    def available(self) -> bool:
+        """Available as long as the coordinator has data."""
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def hvac_mode(self):
+        """OFF if powered off or in DHW-only, else HEAT/COOL by operating mode."""
+        if not self._is_on():
+            return HVACMode.OFF
+        mode = self._raw(MODE_CODE)
+        if mode in COOLING_MODES:
+            return HVACMode.COOL
+        if mode in HEATING_MODES:
+            return HVACMode.HEAT
+        return HVACMode.OFF  # e.g. DHW only — no space conditioning
+
+    @property
+    def current_temperature(self):
+        """Outlet water temperature (T02)."""
+        return self._num(OUTLET_TEMP_CODE)
+
+    def _active_target_codes(self):
+        """Return (target, min, max, default_min, default_max) codes for the
+        current mode, or None when no space-conditioning target applies."""
+        mode = self._raw(MODE_CODE)
+        if mode in COOLING_MODES:
+            return (COOL_TARGET_CODE, COOL_MIN_CODE, COOL_MAX_CODE,
+                    DEFAULT_COOL_MIN, DEFAULT_COOL_MAX)
+        if mode in HEATING_MODES:
+            return (HEAT_TARGET_CODE, HEAT_MIN_CODE, HEAT_MAX_CODE,
+                    DEFAULT_HEAT_MIN, DEFAULT_HEAT_MAX)
+        return None
+
+    @property
+    def target_temperature(self):
+        """Current active space-conditioning setpoint (R02 heat / R03 cool)."""
+        codes = self._active_target_codes()
+        if not codes:
+            return None
+        return self._num(codes[0])
+
+    @property
+    def min_temp(self):
+        """Lower bound of the active setpoint (heat R10 / cool R08)."""
+        codes = self._active_target_codes()
+        if not codes:
+            return DEFAULT_HEAT_MIN
+        v = self._num(codes[1])
+        return v if v is not None else codes[3]
+
+    @property
+    def max_temp(self):
+        """Upper bound of the active setpoint (heat R11 / cool R09)."""
+        codes = self._active_target_codes()
+        if not codes:
+            return DEFAULT_HEAT_MAX
+        v = self._num(codes[2])
+        return v if v is not None else codes[4]
+
+    # -- writes ---------------------------------------------------------------
+    def _device_code(self):
+        if self.coordinator.device_info:
+            return self.coordinator.device_info.get("device_code")
+        return None
+
+    async def _write(self, code, value):
+        """Send one control write and optimistically reflect it locally."""
+        device_code = self._device_code()
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot write %s", code)
+            return
+        LOGGER.info("WarmLink: climate write %s=%s", code, value)
+        resp = await self.coordinator.api.set_value(device_code, code, value)
+        LOGGER.debug("WarmLink: climate %s=%s response: %s", code, value, resp)
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    item["value"] = value
+                    break
+
+    async def async_set_temperature(self, **kwargs):
+        """Write the active setpoint (heat -> R02, cool -> R03)."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is None:
+            return
+        codes = self._active_target_codes()
+        if not codes:
+            LOGGER.warning("WarmLink: set_temperature ignored — no active heat/cool mode")
+            return
+        target = int(round(float(temp)))
+        lo, hi = int(round(self.min_temp)), int(round(self.max_temp))
+        target = max(lo, min(hi, target))
+        await self._write(codes[0], f"{target}.0")
+        if self.coordinator.data:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        """Map OFF/HEAT/COOL to Power + Mode writes."""
+        if hvac_mode == HVACMode.OFF:
+            await self._write(POWER_CODE, "0")
+        elif hvac_mode == HVACMode.HEAT:
+            await self._write(POWER_CODE, "1")
+            await self._write(MODE_CODE, MODE_HEATING)
+        elif hvac_mode == HVACMode.COOL:
+            await self._write(POWER_CODE, "1")
+            await self._write(MODE_CODE, MODE_COOLING)
+        else:
+            LOGGER.warning("WarmLink: unsupported hvac_mode %s", hvac_mode)
+            return
+        if self.coordinator.data:
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+        await self.coordinator.async_request_refresh()
+
+    async def async_turn_on(self):
+        """Turn on — resume heating (safe default)."""
+        await self.async_set_hvac_mode(HVACMode.HEAT)
+
+    async def async_turn_off(self):
+        """Turn off the heat pump."""
+        await self.async_set_hvac_mode(HVACMode.OFF)

--- a/custom_components/warmlink/select.py
+++ b/custom_components/warmlink/select.py
@@ -7,8 +7,10 @@ anti-thermosiphon trick: parking the 3-way diverter off the DHW tank by writing
 loop that otherwise bleeds tank heat out through the (cold) outdoor unit.
 
 Only the modes we have *confirmed* on real hardware are exposed, on purpose:
-writing an unconfirmed Mode value risks selecting a cooling mode. Add more
-options here once they are calibrated against the unit's own panel.
+writing an unconfirmed Mode value risks selecting an unintended mode. The
+confirmed set is DHW only / Heating / Cooling / Heating + DHW / Cooling + DHW
+(raw values 0/1/2/3/4 — see MODE_OPTIONS). Add more options here once they are
+calibrated against the unit's own panel.
 """
 import logging
 
@@ -24,18 +26,26 @@ LOGGER = logging.getLogger(__name__)
 # linked-go/AquaTemp control endpoint and read back on the Mode sensor).
 MODE_CODE = "Mode"
 
-# Confirmed-safe modes only (label -> raw protocol value).
+# Operating modes confirmed on real hardware (label -> raw protocol value).
 #   0 = DHW only        -> 3-way valve to the tank
 #   1 = Heating         -> valve fully off the tank (DHW port closed); the ideal
 #                          anti-siphon park: no DHW component, so no periodic
 #                          forced switch back to the tank (unlike Heating + DHW).
+#   2 = Cooling         -> cooling only; setpoint is the Cooling Target (R03),
+#                          range R08/R09 — separate from the heating/DHW ranges.
 #   3 = Heating + DHW   -> valve toward heating, but the unit forces a switch
 #                          back to DHW on a timer (H32, ~90 min) to service the tank.
-# 2/4/5... are NOT confirmed (possible cooling) and are deliberately omitted.
+#   4 = Cooling + DHW   -> cooling with periodic DHW service (cooling setpoint R03,
+#                          DHW setpoint R01); the DHW half behaves like mode 3.
+# Cooling modes (2/4) only actually engage when H05 (Enable Cooling Function) = 1
+# on the unit; otherwise the firmware ignores the write, same as in the app.
+# Values verified per issue #17.
 MODE_OPTIONS = {
     "DHW only": "0",
     "Heating": "1",
+    "Cooling": "2",
     "Heating + DHW": "3",
+    "Cooling + DHW": "4",
 }
 VALUE_TO_LABEL = {v: k for k, v in MODE_OPTIONS.items()}
 
@@ -46,8 +56,10 @@ async def async_setup_entry(hass, entry, async_add_entities):
     async_add_entities([
         WarmlinkModeSelect(coordinator, entry),
         WarmlinkDHWTargetSelect(coordinator, entry),
+        WarmlinkCoolingTargetSelect(coordinator, entry),
+        WarmlinkHeatingTargetSelect(coordinator, entry),
     ])
-    LOGGER.info("WarmLink: Added operating mode + DHW target selects")
+    LOGGER.info("WarmLink: Added operating mode + DHW/cooling/heating target selects")
 
 
 class WarmlinkModeSelect(CoordinatorEntity, SelectEntity):
@@ -264,6 +276,280 @@ class WarmlinkDHWTargetSelect(CoordinatorEntity, SelectEntity):
         if self.coordinator.data:
             for item in self.coordinator.data:
                 if item.get("code") == DHW_TARGET_CODE:
+                    item["value"] = out
+                    break
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+
+
+# Cooling target temperature as a discrete °C dropdown (writes the R03 code).
+# Mirrors the DHW target select exactly, with cooling codes swapped in:
+#   R03 = Cooling Target Temp (write)   R08 = Min Cooling Target   R09 = Max Cooling Target
+# The selectable range is read live from R08/R09, so it matches each unit's own
+# configured range and tracks changes made in the WarmLink app. Falls back to
+# 7..30 if the range registers are not reported.
+COOL_TARGET_CODE = "R03"
+COOL_MIN_CODE = "R08"
+COOL_MAX_CODE = "R09"
+DEFAULT_COOL_MIN = 7
+DEFAULT_COOL_MAX = 30
+
+
+class WarmlinkCoolingTargetSelect(CoordinatorEntity, SelectEntity):
+    """Writable cooling target temperature as a discrete °C dropdown (R03).
+
+    Resolves the cooling half of issue #17. Like the DHW target, a dropdown of
+    whole-degree options is a single, unambiguous write per change — unlike a
+    stepper/box, which sends one cloud write per increment and races over the
+    slow cloud round-trip. The write only takes effect on the unit while it is
+    in a cooling mode (H05 = Enable Cooling Function = 1); otherwise the value
+    is stored/ignored by the firmware, same as setting it in the app.
+    """
+
+    def __init__(self, coordinator, entry):
+        """Initialize the cooling target select."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_cooling_target_select"
+        self._attr_name = "Cooling Target Temperature"
+        self._attr_icon = "mdi:snowflake-thermometer"
+        # options are computed dynamically from the device range (see `options`)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the sensors/switch/select device)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _code_value(self, code):
+        """Return the raw value of a protocol code, or None if unavailable."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    return item.get("value")
+        return None
+
+    def _range(self):
+        """Return (min, max) °C from the device's R08/R09, else the defaults."""
+        lo, hi = DEFAULT_COOL_MIN, DEFAULT_COOL_MAX
+        try:
+            v = self._code_value(COOL_MIN_CODE)
+            if v not in (None, "", "null"):
+                lo = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        try:
+            v = self._code_value(COOL_MAX_CODE)
+            if v not in (None, "", "null"):
+                hi = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        if lo > hi:  # guard against an implausible / partial report
+            lo, hi = DEFAULT_COOL_MIN, DEFAULT_COOL_MAX
+        return lo, hi
+
+    @property
+    def options(self):
+        """Whole-degree options across the device's reported range (live)."""
+        lo, hi = self._range()
+        return [str(t) for t in range(lo, hi + 1)]
+
+    @property
+    def available(self) -> bool:
+        """Available as long as the coordinator has data."""
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def current_option(self):
+        """Return the current cooling target as a dropdown option (rounded to °C)."""
+        value = self._code_value(COOL_TARGET_CODE)
+        if value in (None, "", "null"):
+            return None
+        try:
+            opt = str(int(round(float(value))))
+        except (TypeError, ValueError):
+            return None
+        return opt if opt in self.options else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the chosen cooling target temperature to the device."""
+        try:
+            target = int(round(float(option)))
+        except (ValueError, TypeError):
+            LOGGER.error("WarmLink: Unrecognised cooling target option %s", option)
+            return
+        if str(target) not in self.options:
+            lo, hi = self._range()
+            LOGGER.error("WarmLink: Cooling target %s out of device range %s-%s", target, lo, hi)
+            return
+
+        device_code = None
+        if self.coordinator.device_info:
+            device_code = self.coordinator.device_info.get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot set cooling target")
+            return
+
+        out = f"{target}.0"
+        LOGGER.info("WarmLink: Requesting cooling target R03=%s (select)", out)
+        resp = await self.coordinator.api.set_value(device_code, COOL_TARGET_CODE, out)
+        LOGGER.info("WarmLink: R03=%s select response: %s", out, resp)
+        # Optimistically reflect the new value so the dropdown updates instantly;
+        # the next scheduled poll reconciles (and corrects if the device clamps).
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == COOL_TARGET_CODE:
+                    item["value"] = out
+                    break
+            self.coordinator.async_set_updated_data(self.coordinator.data)
+
+
+# Heating (space-heating) target temperature as a discrete °C dropdown (R02).
+# Mirrors the DHW/cooling target selects with heating codes swapped in:
+#   R02 = Heating Target Temp (write)   R10 = Min Heating Target   R11 = Max Heating Target
+# Range is read live from R10/R11 and is independent of the cooling (R08/R09) and
+# DHW (R36/R37) ranges. Applies while the unit is in a heating mode (Heating or
+# Heating + DHW). Completes the writable-target set requested in issue #17.
+HEAT_TARGET_CODE = "R02"
+HEAT_MIN_CODE = "R10"
+HEAT_MAX_CODE = "R11"
+DEFAULT_HEAT_MIN = 20
+DEFAULT_HEAT_MAX = 60
+
+
+class WarmlinkHeatingTargetSelect(CoordinatorEntity, SelectEntity):
+    """Writable heating target temperature as a discrete °C dropdown (R02)."""
+
+    def __init__(self, coordinator, entry):
+        """Initialize the heating target select."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_heating_target_select"
+        self._attr_name = "Heating Target Temperature"
+        self._attr_icon = "mdi:radiator"
+        # options are computed dynamically from the device range (see `options`)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the sensors/switch/select device)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _code_value(self, code):
+        """Return the raw value of a protocol code, or None if unavailable."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    return item.get("value")
+        return None
+
+    def _range(self):
+        """Return (min, max) °C from the device's R10/R11, else the defaults."""
+        lo, hi = DEFAULT_HEAT_MIN, DEFAULT_HEAT_MAX
+        try:
+            v = self._code_value(HEAT_MIN_CODE)
+            if v not in (None, "", "null"):
+                lo = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        try:
+            v = self._code_value(HEAT_MAX_CODE)
+            if v not in (None, "", "null"):
+                hi = int(round(float(v)))
+        except (TypeError, ValueError):
+            pass
+        if lo > hi:  # guard against an implausible / partial report
+            lo, hi = DEFAULT_HEAT_MIN, DEFAULT_HEAT_MAX
+        return lo, hi
+
+    @property
+    def options(self):
+        """Whole-degree options across the device's reported range (live)."""
+        lo, hi = self._range()
+        return [str(t) for t in range(lo, hi + 1)]
+
+    @property
+    def available(self) -> bool:
+        """Available as long as the coordinator has data."""
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def current_option(self):
+        """Return the current heating target as a dropdown option (rounded to °C)."""
+        value = self._code_value(HEAT_TARGET_CODE)
+        if value in (None, "", "null"):
+            return None
+        try:
+            opt = str(int(round(float(value))))
+        except (TypeError, ValueError):
+            return None
+        return opt if opt in self.options else None
+
+    async def async_select_option(self, option: str) -> None:
+        """Write the chosen heating target temperature to the device."""
+        try:
+            target = int(round(float(option)))
+        except (ValueError, TypeError):
+            LOGGER.error("WarmLink: Unrecognised heating target option %s", option)
+            return
+        if str(target) not in self.options:
+            lo, hi = self._range()
+            LOGGER.error("WarmLink: Heating target %s out of device range %s-%s", target, lo, hi)
+            return
+
+        device_code = None
+        if self.coordinator.device_info:
+            device_code = self.coordinator.device_info.get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot set heating target")
+            return
+
+        out = f"{target}.0"
+        LOGGER.info("WarmLink: Requesting heating target R02=%s (select)", out)
+        resp = await self.coordinator.api.set_value(device_code, HEAT_TARGET_CODE, out)
+        LOGGER.info("WarmLink: R02=%s select response: %s", out, resp)
+        # Optimistically reflect the new value so the dropdown updates instantly;
+        # the next scheduled poll reconciles (and corrects if the device clamps).
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == HEAT_TARGET_CODE:
                     item["value"] = out
                     break
             self.coordinator.async_set_updated_data(self.coordinator.data)

--- a/custom_components/warmlink/sensor.py
+++ b/custom_components/warmlink/sensor.py
@@ -117,8 +117,87 @@ async def async_setup_entry(hass, entry, async_add_entities):
     if codes_without_icon:
         LOGGER.debug(f"WarmLink: Codes without icon mapping ({len(codes_without_icon)}): {codes_without_icon}")
     
+    # Computed diagnostic: water Delta-T (outlet - inlet). A live "is it actually
+    # transferring heat" indicator that no single raw code provides.
+    entities.append(WarmlinkDeltaTSensor(coord, entry))
+
     LOGGER.info(f"WarmLink: Created {len(entities)} sensor entities")
     async_add_entities(entities, True)
+
+
+# Codes for the computed Delta-T sensor.
+DELTA_T_OUTLET_CODE = "T02"   # Outlet Water Temp
+DELTA_T_INLET_CODE = "T01"    # Inlet Water Temp
+
+
+class WarmlinkDeltaTSensor(CoordinatorEntity, SensorEntity):
+    """Computed water Delta-T = Outlet (T02) - Inlet (T01), in °C.
+
+    Positive while heating (outlet warmer than inlet), negative while cooling.
+    Not a raw device code — derived from the two water-temperature sensors so it
+    works on any unit that reports T01/T02.
+    """
+
+    def __init__(self, coord, entry):
+        """Initialize the Delta-T sensor."""
+        super().__init__(coord)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_water_delta_t"
+        self._attr_name = "Water Delta-T [T02-T01]"
+        self._attr_icon = "mdi:thermometer-lines"
+        self._attr_native_unit_of_measurement = "°C"
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the other WarmLink entities)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _num(self, code):
+        """Return a protocol code's value as float, or None if unusable."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    v = item.get("value")
+                    if v in (None, "", "null"):
+                        return None
+                    try:
+                        return float(v)
+                    except (TypeError, ValueError):
+                        return None
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Available only when both source temperatures are readable."""
+        return self._num(DELTA_T_OUTLET_CODE) is not None and self._num(DELTA_T_INLET_CODE) is not None
+
+    @property
+    def native_value(self):
+        """Return outlet minus inlet, rounded to 1 decimal."""
+        outlet = self._num(DELTA_T_OUTLET_CODE)
+        inlet = self._num(DELTA_T_INLET_CODE)
+        if outlet is None or inlet is None:
+            return None
+        return round(outlet - inlet, 1)
+
 
 class WarmlinkSensor(CoordinatorEntity, SensorEntity):
     """Representation of a WarmLink sensor."""

--- a/custom_components/warmlink/water_heater.py
+++ b/custom_components/warmlink/water_heater.py
@@ -1,0 +1,146 @@
+"""Water heater platform for WarmLink integration.
+
+Exposes the domestic-hot-water (DHW) side of the heat pump as a standard Home
+Assistant ``water_heater`` entity, so it renders as a proper hot-water tank card
+with a temperature dial:
+
+  current_temperature = DHW tank temp  (T08)
+  target_temperature  = DHW setpoint   (R01, writable via the cloud control API)
+  min/max             = device's own DHW range (R36 / R37, read live)
+
+This is complementary to the DHW Target *select*: same underlying R01 write, but
+a nicer card and a first-class target for the HA UI/voice/automations.
+"""
+import logging
+
+from homeassistant.components.water_heater import (
+    WaterHeaterEntity,
+    WaterHeaterEntityFeature,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+DHW_TARGET_CODE = "R01"
+DHW_MIN_CODE = "R36"
+DHW_MAX_CODE = "R37"
+DHW_TANK_TEMP_CODE = "T08"
+DEFAULT_MIN = 47
+DEFAULT_MAX = 60
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the WarmLink DHW water heater entity."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([WarmlinkDHWWaterHeater(coordinator, entry)])
+    LOGGER.info("WarmLink: Added DHW water heater entity")
+
+
+class WarmlinkDHWWaterHeater(CoordinatorEntity, WaterHeaterEntity):
+    """DHW tank as a water_heater entity (writes R01)."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_supported_features = WaterHeaterEntityFeature.TARGET_TEMPERATURE
+    _attr_target_temperature_step = 1
+
+    def __init__(self, coordinator, entry):
+        """Initialize the water heater."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_dhw_water_heater"
+        self._attr_name = "Hot Water"
+        self._attr_icon = "mdi:water-boiler"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the other WarmLink entities)."""
+        device_name = "WarmLink"
+        device_model = "Heat Pump"
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _num(self, code):
+        """Return a protocol code's value as float, or None if unusable."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == code:
+                    v = item.get("value")
+                    if v in (None, "", "null"):
+                        return None
+                    try:
+                        return float(v)
+                    except (TypeError, ValueError):
+                        return None
+        return None
+
+    @property
+    def available(self) -> bool:
+        """Available as long as the coordinator has data."""
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def min_temp(self):
+        """Lower bound of the DHW setpoint (live from R36)."""
+        v = self._num(DHW_MIN_CODE)
+        return v if v is not None else DEFAULT_MIN
+
+    @property
+    def max_temp(self):
+        """Upper bound of the DHW setpoint (live from R37)."""
+        v = self._num(DHW_MAX_CODE)
+        return v if v is not None else DEFAULT_MAX
+
+    @property
+    def current_temperature(self):
+        """Current DHW tank temperature (T08)."""
+        return self._num(DHW_TANK_TEMP_CODE)
+
+    @property
+    def target_temperature(self):
+        """Current DHW setpoint (R01)."""
+        return self._num(DHW_TARGET_CODE)
+
+    async def async_set_temperature(self, **kwargs):
+        """Write a new DHW setpoint (whole degrees)."""
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is None:
+            return
+        target = int(round(float(temp)))
+        lo, hi = int(round(self.min_temp)), int(round(self.max_temp))
+        target = max(lo, min(hi, target))  # clamp into the device range
+
+        device_code = None
+        if self.coordinator.device_info:
+            device_code = self.coordinator.device_info.get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot set DHW target")
+            return
+
+        out = f"{target}.0"
+        LOGGER.info("WarmLink: Requesting DHW target R01=%s (water_heater)", out)
+        resp = await self.coordinator.api.set_value(device_code, DHW_TARGET_CODE, out)
+        LOGGER.info("WarmLink: R01=%s water_heater response: %s", out, resp)
+        # Optimistic local update; the next poll reconciles.
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == DHW_TARGET_CODE:
+                    item["value"] = out
+                    break
+            self.coordinator.async_set_updated_data(self.coordinator.data)


### PR DESCRIPTION
# Add cooling modes, cooling/heating targets, and climate + water_heater entities

## Summary

This rounds out space-conditioning and DHW control, and resolves the cooling
half of #17 (Cooling mode and Cooling target temperature were not exposed or
writable).

All operating-mode values were verified against the real device's raw registers
before being exposed, per the discussion in #17.

## Changes

**`select.py`**
- Expose the confirmed **Cooling (2)** and **Cooling + DHW (4)** operating modes
  in the Operating Mode select (previously only DHW only / Heating / Heating + DHW).
- Add a writable **Cooling Target Temperature** select (`R03`, range read live
  from `R08`/`R09`).
- Add a writable **Heating Target Temperature** select (`R02`, range `R10`/`R11`).
  Both mirror the existing DHW-target select: a whole-degree dropdown, which is a
  single unambiguous cloud write per change rather than one write per increment.

**`climate.py`** (new) — space-conditioning thermostat entity
- `hvac_mode` OFF / HEAT / COOL maps to the whole-unit Power + Mode.
- Target temperature routes to `R02` (heat) or `R03` (cool) depending on mode,
  with min/max taken live from the device's own range registers.
- `current_temperature` = Outlet Water Temp (`T02`), the process temperature the
  unit actually regulates.

**`water_heater.py`** (new) — DHW tank as a first-class `water_heater` entity
- Target `R01`, current temp `T08` (tank), range `R36`/`R37`.
- Complementary to the DHW-target select (same underlying write) but renders as a
  proper hot-water card and is a first-class target for the UI/voice/automations.

**`sensor.py`**
- Add a computed water **Delta-T** diagnostic sensor (`T02 − T01`): a live
  "is it actually transferring heat" indicator that no single raw code provides.

**`__init__.py`**
- Register the new `climate` and `water_heater` platforms.

## Notes

- Cooling modes (2/4) only physically engage when the unit's **Enable Cooling
  Function** (`H05`) is set; otherwise the firmware ignores the write, exactly as
  the vendor app does. This is documented inline.
- The climate entity governs space conditioning only; DHW keeps its own entity.
  The combined "+ DHW" modes read back as HEAT/COOL on the thermostat — selecting
  a "+ DHW" combo explicitly is still done via the Operating Mode select.
- No changes to `coordinator.py` or the API layer; the new entities use the
  existing `api.set_value` / coordinator data.
- Happy to split this into smaller PRs (e.g. cooling-only for #17 first) if you'd
  prefer a narrower change set.

## Testing

Running on a live GT09-TP (WarmLink cloud): cooling/heating mode switches, target
writes in both modes, the DHW card, and the Delta-T sensor all behave as expected.
All five changed files pass `py_compile`.
