### PR TITLE
Add LinkedGo smart radiator support (Scantherm LT fan coils): productId routing, climate entity, full mode enum

### DIFF
--- a/custom_components/warmlink/__init__.py
+++ b/custom_components/warmlink/__init__.py
@@ -5,7 +5,7 @@ import logging
 
 LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["sensor", "button", "switch", "select"]
+PLATFORMS = ["sensor", "button", "switch", "select", "climate"]
 
 async def async_setup(hass, config):
     """Set up the WarmLink component."""

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -35,7 +35,9 @@ CURRENT_CODE = "T1"
 HEAT_LEVEL_CODE = "Fan_Speed_Setting"
 MIN_TEMP_CODE = "R05"
 MAX_TEMP_CODE = "R01"      # limit for the heating dial (raising it widens the app/panel range)
-POWER_KW_CODE = "2013"
+FAN_RUNNING_CODE = "O2"    # ~1600 while the fan actually spins, 0 at rest.
+                           # NOTE: "2013" reads a constant 1.2 (rated value, NOT
+                           # live draw) — do not use it for activity detection.
 
 # Mode enum — verified on hardware 2026-08-15 (panel LEDs while switching):
 #   "1" = COOLING, "4" = HEATING. Other values unobserved.
@@ -152,10 +154,10 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     def hvac_action(self):
         if self.hvac_mode == HVACMode.OFF:
             return HVACAction.OFF
-        kw = self._float(POWER_KW_CODE)
-        if kw is None:
+        rpm = self._float(FAN_RUNNING_CODE)
+        if rpm is None:
             return None
-        if kw <= 0:
+        if rpm <= 0:
             return HVACAction.IDLE
         mode = self._device_mode()
         if mode == MODE_COOL:

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -80,6 +80,9 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         # R05/R01 doesn't make the UI flap back to the hardcoded defaults.
         self._min_temp = 5.0
         self._max_temp = 30.0
+        # Optimistic mode after a mode write, so an immediate set_temperature
+        # targets the RIGHT register instead of racing the 120 s poll.
+        self._pending_mode = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -118,8 +121,18 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     def available(self) -> bool:
         return bool(self.coordinator.data) and self.coordinator.last_update_success
 
+    def _device_mode(self):
+        """Effective mode: optimistic pending value until the poll confirms it."""
+        polled = str(self.coordinator.value(MODE_CODE))
+        if self._pending_mode is not None:
+            if polled == self._pending_mode:
+                self._pending_mode = None  # confirmed by device
+            else:
+                return self._pending_mode
+        return polled
+
     def _is_cooling_mode(self):
-        return str(self.coordinator.value(MODE_CODE)) == MODE_COOL
+        return self._device_mode() == MODE_COOL
 
     @property
     def hvac_mode(self):
@@ -128,7 +141,7 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
             return None
         if str(v).strip() in ("0", "0.0"):
             return HVACMode.OFF
-        mode = str(self.coordinator.value(MODE_CODE))
+        mode = self._device_mode()
         if mode == MODE_COOL:
             return HVACMode.COOL
         if mode == MODE_HEAT:
@@ -144,7 +157,12 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
             return None
         if kw <= 0:
             return HVACAction.IDLE
-        return HVACAction.COOLING if self._is_cooling_mode() else HVACAction.HEATING
+        mode = self._device_mode()
+        if mode == MODE_COOL:
+            return HVACAction.COOLING
+        if mode == MODE_HEAT:
+            return HVACAction.HEATING
+        return None  # active in an unmapped mode — don't misreport
 
     @property
     def current_temperature(self):
@@ -207,7 +225,8 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
             await self._set(POWER_CODE, "0")
             return
         target = MODE_COOL if hvac_mode == HVACMode.COOL else MODE_HEAT
-        if str(self.coordinator.value(MODE_CODE)) != target:
+        if self._device_mode() != target:
+            self._pending_mode = target
             await self._set(MODE_CODE, target)
         await self._set(POWER_CODE, "1")
 

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -69,6 +69,10 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         self._entry = entry
         self._attr_unique_id = f"{entry.entry_id}_radiator_climate"
         self._attr_name = None  # use the device name
+        # Cache the last known device limits so a poll that happens to miss
+        # R05/R01 doesn't make the UI flap back to the hardcoded defaults.
+        self._min_temp = 5.0
+        self._max_temp = 30.0
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -133,11 +137,17 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def min_temp(self):
-        return self._float(MIN_TEMP_CODE) or 5.0
+        v = self._float(MIN_TEMP_CODE)
+        if v is not None:
+            self._min_temp = v
+        return self._min_temp
 
     @property
     def max_temp(self):
-        return self._float(MAX_TEMP_CODE) or 30.0
+        v = self._float(MAX_TEMP_CODE)
+        if v is not None:
+            self._max_temp = v
+        return self._max_temp
 
     @property
     def fan_mode(self):

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -1,0 +1,175 @@
+"""Climate platform for WarmLink smart radiators.
+
+Only set up for devices whose productId is in RADIATOR_PRODUCT_IDS (LinkedGo
+smart radiators, e.g. Scantherm panels). Heat pumps keep their existing
+sensor/switch/select entities and are not affected.
+
+Protocol (verified against real hardware via app capture):
+  Power             "1"/"0"        on/off
+  R02               float          target temperature (°C, writable)
+  T1                float          current room temperature (°C)
+  Fan_Speed_Setting "1".."6"       heat level (writable)
+  R05 / R01         float          min (anti-freeze) / max temperature limits
+  2013              float          current power draw (kW) -> hvac_action
+"""
+import logging
+
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityFeature,
+    HVACAction,
+    HVACMode,
+)
+from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
+from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import DOMAIN
+
+LOGGER = logging.getLogger(__name__)
+
+POWER_CODE = "Power"
+TARGET_CODE = "R02"
+CURRENT_CODE = "T1"
+HEAT_LEVEL_CODE = "Fan_Speed_Setting"
+MIN_TEMP_CODE = "R05"
+MAX_TEMP_CODE = "R01"
+POWER_KW_CODE = "2013"
+
+HEAT_LEVELS = ["1", "2", "3", "4", "5", "6"]
+
+
+async def async_setup_entry(hass, entry, async_add_entities):
+    """Set up the radiator climate entity (radiators only)."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    if not coordinator.is_radiator:
+        LOGGER.debug("WarmLink: Not a radiator — skipping climate platform")
+        return
+    async_add_entities([WarmlinkRadiatorClimate(coordinator, entry)])
+    LOGGER.info("WarmLink: Added radiator climate entity")
+
+
+class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
+    """Climate entity for a LinkedGo/WarmLink smart radiator."""
+
+    _attr_temperature_unit = UnitOfTemperature.CELSIUS
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_fan_modes = HEAT_LEVELS
+    _attr_target_temperature_step = 0.5
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE
+        | ClimateEntityFeature.FAN_MODE
+        | ClimateEntityFeature.TURN_ON
+        | ClimateEntityFeature.TURN_OFF
+    )
+
+    def __init__(self, coordinator, entry):
+        """Initialize the climate entity."""
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_radiator_climate"
+        self._attr_name = None  # use the device name
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return device info (matches the sensors/switch device)."""
+        device_name = "WarmLink"
+        device_model = "Radiator"
+
+        if self.coordinator.device_info:
+            nick = self.coordinator.device_info.get("device_nick_name")
+            cust_model = self.coordinator.device_info.get("cust_model")
+
+            if nick and nick.strip():
+                device_name = nick
+            elif cust_model and cust_model.strip():
+                device_name = cust_model
+
+            if cust_model and cust_model.strip():
+                device_model = cust_model
+
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._entry.entry_id)},
+            name=device_name,
+            manufacturer="WarmLink",
+            model=device_model,
+        )
+
+    def _float(self, code):
+        """Coordinator value as float, or None."""
+        v = self.coordinator.value(code)
+        try:
+            return float(v)
+        except (TypeError, ValueError):
+            return None
+
+    @property
+    def available(self) -> bool:
+        return bool(self.coordinator.data) and self.coordinator.last_update_success
+
+    @property
+    def hvac_mode(self):
+        v = self.coordinator.value(POWER_CODE)
+        if v is None:
+            return None
+        return HVACMode.OFF if str(v).strip() in ("0", "0.0") else HVACMode.HEAT
+
+    @property
+    def hvac_action(self):
+        if self.hvac_mode == HVACMode.OFF:
+            return HVACAction.OFF
+        kw = self._float(POWER_KW_CODE)
+        if kw is None:
+            return None
+        return HVACAction.HEATING if kw > 0 else HVACAction.IDLE
+
+    @property
+    def current_temperature(self):
+        return self._float(CURRENT_CODE)
+
+    @property
+    def target_temperature(self):
+        return self._float(TARGET_CODE)
+
+    @property
+    def min_temp(self):
+        return self._float(MIN_TEMP_CODE) or 5.0
+
+    @property
+    def max_temp(self):
+        return self._float(MAX_TEMP_CODE) or 30.0
+
+    @property
+    def fan_mode(self):
+        v = self.coordinator.value(HEAT_LEVEL_CODE)
+        if v is None:
+            return None
+        v = str(int(float(v))) if str(v).replace(".", "").isdigit() else str(v)
+        return v if v in HEAT_LEVELS else None
+
+    async def _set(self, code, value):
+        device_code = (self.coordinator.device_info or {}).get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot control radiator")
+            return
+        await self.coordinator.api.set_value(device_code, code, value)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_temperature(self, **kwargs):
+        temp = kwargs.get(ATTR_TEMPERATURE)
+        if temp is None:
+            return
+        await self._set(TARGET_CODE, f"{float(temp):.1f}")
+
+    async def async_set_fan_mode(self, fan_mode):
+        if fan_mode in HEAT_LEVELS:
+            await self._set(HEAT_LEVEL_CODE, fan_mode)
+
+    async def async_set_hvac_mode(self, hvac_mode):
+        await self._set(POWER_CODE, "0" if hvac_mode == HVACMode.OFF else "1")
+
+    async def async_turn_on(self):
+        await self._set(POWER_CODE, "1")
+
+    async def async_turn_off(self):
+        await self._set(POWER_CODE, "0")

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -39,10 +39,16 @@ FAN_RUNNING_CODE = "O2"    # ~1600 while the fan actually spins, 0 at rest.
                            # NOTE: "2013" reads a constant 1.2 (rated value, NOT
                            # live draw) — do not use it for activity detection.
 
-# Mode enum — verified on hardware 2026-08-15 (panel LEDs while switching):
-#   "1" = COOLING, "4" = HEATING. Other values unobserved.
+# Mode enum — verified on hardware 2026-08-15 (panel LEDs/display during a
+# controlled sweep with the owner watching): 0=auto, 1=cooling,
+# 2=dehumidify ("dEH" on the display), 3=fan-only (ventilation), 4=heating.
+# Value 5 is rejected by the device (snaps back to 0). Dehumidify is not
+# exposed: it needs cold water the radiator loop doesn't have.
 MODE_CODE = "Mode"
+MODE_AUTO = "0"
 MODE_COOL = "1"
+MODE_DRY = "2"
+MODE_FAN = "3"
 MODE_HEAT = "4"
 
 HEAT_LEVELS = ["1", "2", "3", "4", "5", "6"]
@@ -62,7 +68,7 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     """Climate entity for a LinkedGo/WarmLink smart radiator."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL, HVACMode.FAN_ONLY, HVACMode.AUTO, HVACMode.OFF]
     _attr_fan_modes = HEAT_LEVELS
     _attr_target_temperature_step = 0.5
     _attr_supported_features = (
@@ -144,11 +150,13 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         if str(v).strip() in ("0", "0.0"):
             return HVACMode.OFF
         mode = self._device_mode()
-        if mode == MODE_COOL:
-            return HVACMode.COOL
-        if mode == MODE_HEAT:
-            return HVACMode.HEAT
-        return None  # unobserved mode value — don't guess
+        return {
+            MODE_AUTO: HVACMode.AUTO,
+            MODE_COOL: HVACMode.COOL,
+            MODE_DRY: HVACMode.DRY,  # reachable from the panel, shown truthfully
+            MODE_FAN: HVACMode.FAN_ONLY,
+            MODE_HEAT: HVACMode.HEAT,
+        }.get(mode)
 
     @property
     def hvac_action(self):
@@ -164,7 +172,9 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
             return HVACAction.COOLING
         if mode == MODE_HEAT:
             return HVACAction.HEATING
-        return None  # active in an unmapped mode — don't misreport
+        if mode in (MODE_FAN, MODE_DRY):
+            return HVACAction.FAN
+        return None  # auto/unmapped while spinning — direction unknown, don't guess
 
     @property
     def current_temperature(self):
@@ -174,6 +184,9 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     def target_temperature(self):
         # The panel's SET TEMP follows the active mode: R03 in cooling, R02 in
         # heating — mirror that so HA always shows what the display shows.
+        # Fan-only has no setpoint.
+        if self._device_mode() == MODE_FAN:
+            return None
         code = COOL_TARGET_CODE if self._is_cooling_mode() else HEAT_TARGET_CODE
         return self._float(code)
 
@@ -215,6 +228,9 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
+        if self._device_mode() == MODE_FAN:
+            LOGGER.debug("WarmLink: Ignoring set_temperature in fan-only mode")
+            return
         code = COOL_TARGET_CODE if self._is_cooling_mode() else HEAT_TARGET_CODE
         await self._set(code, f"{float(temp):.1f}")
 
@@ -226,7 +242,11 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         if hvac_mode == HVACMode.OFF:
             await self._set(POWER_CODE, "0")
             return
-        target = MODE_COOL if hvac_mode == HVACMode.COOL else MODE_HEAT
+        target = {
+            HVACMode.COOL: MODE_COOL,
+            HVACMode.FAN_ONLY: MODE_FAN,
+            HVACMode.AUTO: MODE_AUTO,
+        }.get(hvac_mode, MODE_HEAT)
         if self._device_mode() != target:
             self._pending_mode = target
             await self._set(MODE_CODE, target)

--- a/custom_components/warmlink/climate.py
+++ b/custom_components/warmlink/climate.py
@@ -29,12 +29,19 @@ from .const import DOMAIN
 LOGGER = logging.getLogger(__name__)
 
 POWER_CODE = "Power"
-TARGET_CODE = "R02"
+HEAT_TARGET_CODE = "R02"   # heating setpoint (panel SET TEMP in heating mode)
+COOL_TARGET_CODE = "R03"   # cooling setpoint (panel SET TEMP in cooling mode)
 CURRENT_CODE = "T1"
 HEAT_LEVEL_CODE = "Fan_Speed_Setting"
 MIN_TEMP_CODE = "R05"
-MAX_TEMP_CODE = "R01"
+MAX_TEMP_CODE = "R01"      # limit for the heating dial (raising it widens the app/panel range)
 POWER_KW_CODE = "2013"
+
+# Mode enum — verified on hardware 2026-08-15 (panel LEDs while switching):
+#   "1" = COOLING, "4" = HEATING. Other values unobserved.
+MODE_CODE = "Mode"
+MODE_COOL = "1"
+MODE_HEAT = "4"
 
 HEAT_LEVELS = ["1", "2", "3", "4", "5", "6"]
 
@@ -53,7 +60,7 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     """Climate entity for a LinkedGo/WarmLink smart radiator."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
-    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.OFF]
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
     _attr_fan_modes = HEAT_LEVELS
     _attr_target_temperature_step = 0.5
     _attr_supported_features = (
@@ -111,12 +118,22 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
     def available(self) -> bool:
         return bool(self.coordinator.data) and self.coordinator.last_update_success
 
+    def _is_cooling_mode(self):
+        return str(self.coordinator.value(MODE_CODE)) == MODE_COOL
+
     @property
     def hvac_mode(self):
         v = self.coordinator.value(POWER_CODE)
         if v is None:
             return None
-        return HVACMode.OFF if str(v).strip() in ("0", "0.0") else HVACMode.HEAT
+        if str(v).strip() in ("0", "0.0"):
+            return HVACMode.OFF
+        mode = str(self.coordinator.value(MODE_CODE))
+        if mode == MODE_COOL:
+            return HVACMode.COOL
+        if mode == MODE_HEAT:
+            return HVACMode.HEAT
+        return None  # unobserved mode value — don't guess
 
     @property
     def hvac_action(self):
@@ -125,7 +142,9 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         kw = self._float(POWER_KW_CODE)
         if kw is None:
             return None
-        return HVACAction.HEATING if kw > 0 else HVACAction.IDLE
+        if kw <= 0:
+            return HVACAction.IDLE
+        return HVACAction.COOLING if self._is_cooling_mode() else HVACAction.HEATING
 
     @property
     def current_temperature(self):
@@ -133,10 +152,15 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def target_temperature(self):
-        return self._float(TARGET_CODE)
+        # The panel's SET TEMP follows the active mode: R03 in cooling, R02 in
+        # heating — mirror that so HA always shows what the display shows.
+        code = COOL_TARGET_CODE if self._is_cooling_mode() else HEAT_TARGET_CODE
+        return self._float(code)
 
     @property
     def min_temp(self):
+        if self._is_cooling_mode():
+            return 5.0  # cooling dial limits are unmapped — permissive static range
         v = self._float(MIN_TEMP_CODE)
         if v is not None:
             self._min_temp = v
@@ -144,6 +168,8 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
 
     @property
     def max_temp(self):
+        if self._is_cooling_mode():
+            return 35.0  # cooling dial limits are unmapped — permissive static range
         v = self._float(MAX_TEMP_CODE)
         if v is not None:
             self._max_temp = v
@@ -169,14 +195,21 @@ class WarmlinkRadiatorClimate(CoordinatorEntity, ClimateEntity):
         temp = kwargs.get(ATTR_TEMPERATURE)
         if temp is None:
             return
-        await self._set(TARGET_CODE, f"{float(temp):.1f}")
+        code = COOL_TARGET_CODE if self._is_cooling_mode() else HEAT_TARGET_CODE
+        await self._set(code, f"{float(temp):.1f}")
 
     async def async_set_fan_mode(self, fan_mode):
         if fan_mode in HEAT_LEVELS:
             await self._set(HEAT_LEVEL_CODE, fan_mode)
 
     async def async_set_hvac_mode(self, hvac_mode):
-        await self._set(POWER_CODE, "0" if hvac_mode == HVACMode.OFF else "1")
+        if hvac_mode == HVACMode.OFF:
+            await self._set(POWER_CODE, "0")
+            return
+        target = MODE_COOL if hvac_mode == HVACMode.COOL else MODE_HEAT
+        if str(self.coordinator.value(MODE_CODE)) != target:
+            await self._set(MODE_CODE, target)
+        await self._set(POWER_CODE, "1")
 
     async def async_turn_on(self):
         await self._set(POWER_CODE, "1")

--- a/custom_components/warmlink/config_flow.py
+++ b/custom_components/warmlink/config_flow.py
@@ -52,7 +52,10 @@ class WarmlinkConfigFlow(config_entries.ConfigFlow, domain="warmlink"):
         if user_input is not None:
             errors = await _validate(self.hass, user_input)
             if not errors:
-                return self.async_create_entry(title="WarmLink", data=user_input)
+                title = "WarmLink"
+                if user_input.get("device_code"):
+                    title = f"WarmLink {user_input['device_code']}"
+                return self.async_create_entry(title=title, data=user_input)
 
         return self.async_show_form(
             step_id="user",

--- a/custom_components/warmlink/const.py
+++ b/custom_components/warmlink/const.py
@@ -1,2 +1,17 @@
 DOMAIN='warmlink'
 UPDATE_INTERVAL=120
+
+# Product IDs that identify LinkedGo smart radiators (e.g. Scantherm panel
+# radiators). These speak a much smaller protocol than the heat pumps, so the
+# coordinator polls RADIATOR_CODES instead of the full heat-pump codes.json.
+RADIATOR_PRODUCT_IDS = {"1473911871244337152"}
+
+# The full radiator protocol as captured from the WarmLink app (18 codes).
+# R02 = target temperature (write-confirmed), T1 = current room temperature,
+# Fan_Speed_Setting = heat level 1-6, Fault1 = 16-bit fault mask.
+RADIATOR_CODES = [
+    "Power", "Mode", "Power_Timer", "Power_Timer_Hours",
+    "Fan_Speed_Setting", "Sleep",
+    "R01", "R02", "R03", "R05", "R06",
+    "2013", "T1", "H05", "Fault1", "O2", "O5", "H06",
+]

--- a/custom_components/warmlink/coordinator.py
+++ b/custom_components/warmlink/coordinator.py
@@ -24,7 +24,15 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator."""
         self.hass = hass
         self.entry = entry
-        self.api = WarmlinkAPI(entry.data["username"], entry.data["password"], hass)
+        # The LinkedGo cloud invalidates the previous token on every new login
+        # (one active token per account). Share ONE API client — and thereby one
+        # token — across all config entries for the same account, so multiple
+        # devices (e.g. several radiators) don't fight over the session.
+        api_pool = hass.data.setdefault(DOMAIN, {}).setdefault("_api_pool", {})
+        pool_key = entry.data["username"]
+        if pool_key not in api_pool:
+            api_pool[pool_key] = WarmlinkAPI(entry.data["username"], entry.data["password"], hass)
+        self.api = api_pool[pool_key]
         self.codes = _CODES
         # A device_code in the config entry means the user supplied it manually
         # (members/shared accounts, whose cloud device list comes back empty —

--- a/custom_components/warmlink/coordinator.py
+++ b/custom_components/warmlink/coordinator.py
@@ -2,7 +2,7 @@
 from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from .managers.warmlink_api import WarmlinkAPI
-from .const import DOMAIN, UPDATE_INTERVAL
+from .const import DOMAIN, UPDATE_INTERVAL, RADIATOR_PRODUCT_IDS, RADIATOR_CODES
 import json, os, logging
 
 LOGGER = logging.getLogger(__name__)
@@ -42,6 +42,7 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
         } if self._device_code else None
         self._logged_unknown_codes = set()  # Track unknown codes we've already logged
         self._logged_missing_codes = set()  # Track missing codes we've already logged
+        self._discovery_attempted = False  # Manual device_code: one-shot device-list enrichment
         super().__init__(
             hass,
             LOGGER,
@@ -50,6 +51,22 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
         )
         LOGGER.info(f"WarmLink: Coordinator initialized with {UPDATE_INTERVAL}s update interval")
     
+    @property
+    def is_radiator(self):
+        """True when the connected device is a LinkedGo smart radiator."""
+        if not self.device_info:
+            return False
+        return str(self.device_info.get("product_id")) in RADIATOR_PRODUCT_IDS
+
+    def value(self, code):
+        """Return the current raw value for a protocol code, or None."""
+        for item in self.data or []:
+            if item.get("code") == code:
+                v = item.get("value")
+                if v not in (None, "", "null"):
+                    return v
+        return None
+
     async def _async_update_data(self):
         """Fetch data from API."""
         LOGGER.info(f"WarmLink: Starting scheduled update at {self.hass.loop.time()}")
@@ -80,7 +97,35 @@ class WarmlinkCoordinator(DataUpdateCoordinator):
                     "sn": device.get("sn"),
                 }
                 LOGGER.info(f"WarmLink: Connected to device {self.device_info.get('device_nick_name')} ({self.device_info.get('cust_model')})")
-            
+            elif not self._discovery_attempted and self.device_info and self.device_info.get("product_id") is None:
+                # Manual device_code: try one device-list call to enrich device_info
+                # (nickname + product_id, which drives radiator/heat-pump routing).
+                # Member/shared accounts get an empty list back — that is fine, we
+                # just keep the manual code and default to heat-pump codes.
+                self._discovery_attempted = True
+                try:
+                    devs = await self.api.get_devices()
+                    for device in (devs or {}).get("objectResult") or []:
+                        if device.get("deviceCode") == self._device_code:
+                            self.device_info = {
+                                "device_code": device.get("deviceCode"),
+                                "device_nick_name": device.get("deviceNickName"),
+                                "product_id": device.get("productId"),
+                                "device_id": device.get("deviceId"),
+                                "cust_model": device.get("custModel"),
+                                "model": device.get("model"),
+                                "sn": device.get("sn"),
+                            }
+                            LOGGER.info(f"WarmLink: Enriched manual device {self.device_info.get('device_nick_name')} (productId {self.device_info.get('product_id')})")
+                            break
+                except Exception as e:
+                    LOGGER.debug(f"WarmLink: Device-list enrichment skipped: {e}")
+
+            # Route to the lean radiator protocol when the product id says so.
+            if self.is_radiator and self.codes is not RADIATOR_CODES:
+                self.codes = RADIATOR_CODES
+                LOGGER.info(f"WarmLink: Radiator detected — polling {len(RADIATOR_CODES)} radiator codes instead of {len(_CODES)} heat-pump codes")
+
             # Fetch property data in batches
             results = []
             codes_requested = set()

--- a/custom_components/warmlink/managers/warmlink_api.py
+++ b/custom_components/warmlink/managers/warmlink_api.py
@@ -1,4 +1,5 @@
 
+import asyncio
 import hashlib
 import logging
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -30,9 +31,18 @@ class WarmlinkAPI:
         self.base_url = "https://cloud.linked-go.com:449/crmservice/api"
         self.session = async_get_clientsession(hass)
         self.token = None
-    
+        # The cloud only allows ONE active token per account: every new login
+        # invalidates the previous token (verified empirically — old token gets
+        # error_code -100). Serialise logins so concurrent coordinators sharing
+        # this client don't stampede and invalidate each other's fresh tokens.
+        self._login_lock = asyncio.Lock()
+
     async def login(self):
-        """Login to the API."""
+        """Login to the API (serialised — see _login_lock note)."""
+        async with self._login_lock:
+            return await self._login_inner()
+
+    async def _login_inner(self):
         LOGGER.debug(f"WarmLink API: Attempting login for user {self.username}")
         payload = {"userName": self.username, "password": self.password}
         try:

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.4",
+  "version": "73.5",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.5",
+  "version": "73.6",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.3",
+  "version": "73.4",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.1",
+  "version": "73.2",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.0",
+  "version": "73.1",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/manifest.json
+++ b/custom_components/warmlink/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "warmlink",
   "name": "WarmLink",
-  "version": "73.2",
+  "version": "73.3",
   "requirements": [
     "aiohttp"
   ],

--- a/custom_components/warmlink/select.py
+++ b/custom_components/warmlink/select.py
@@ -43,6 +43,11 @@ VALUE_TO_LABEL = {v: k for k, v in MODE_OPTIONS.items()}
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up WarmLink select entities."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
+    if getattr(coordinator, "is_radiator", False):
+        # Radiators have no DHW tank or diverter valve, and their Mode values
+        # have different semantics — the climate entity covers their controls.
+        LOGGER.debug("WarmLink: Radiator — skipping heat-pump mode/DHW selects")
+        return
     async_add_entities([
         WarmlinkModeSelect(coordinator, entry),
         WarmlinkDHWTargetSelect(coordinator, entry),

--- a/custom_components/warmlink/switch.py
+++ b/custom_components/warmlink/switch.py
@@ -15,8 +15,14 @@ POWER_CODE = "Power"
 async def async_setup_entry(hass, entry, async_add_entities):
     """Set up WarmLink switch entities."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([WarmlinkPowerSwitch(coordinator, entry)])
-    LOGGER.info("WarmLink: Added power switch")
+    entities = [WarmlinkPowerSwitch(coordinator, entry)]
+    if getattr(coordinator, "is_radiator", False):
+        # Deliberately a SEPARATE switch (not a climate hvac mode): enabling the
+        # cooling function must be an explicit two-step act, so a stray tap on
+        # the thermostat card can never start cooling on uninsulated pipes.
+        entities.append(WarmlinkCoolingFunctionSwitch(coordinator, entry))
+    async_add_entities(entities)
+    LOGGER.info("WarmLink: Added %d switch(es)", len(entities))
 
 
 class WarmlinkPowerSwitch(CoordinatorEntity, SwitchEntity):
@@ -104,3 +110,38 @@ class WarmlinkPowerSwitch(CoordinatorEntity, SwitchEntity):
     async def async_turn_off(self, **kwargs) -> None:
         """Turn the heat pump off."""
         await self._set_power(False)
+
+
+# Radiator cooling-function gate. H05=0 keeps the device heat-only (the app's
+# cooling button is dead); H05=1 unlocks cooling. Write-verified on hardware.
+COOLING_FUNCTION_CODE = "H05"
+
+
+class WarmlinkCoolingFunctionSwitch(WarmlinkPowerSwitch):
+    """Explicit enable/disable of the radiator's cooling function (H05)."""
+
+    def __init__(self, coordinator, entry):
+        """Initialize the switch."""
+        super().__init__(coordinator, entry)
+        self._attr_unique_id = f"{entry.entry_id}_cooling_function_switch"
+        self._attr_name = "Kølefunktion"
+        self._attr_icon = "mdi:snowflake"
+
+    def _power_value(self):
+        """Return the raw H05 value (overrides the Power lookup)."""
+        if self.coordinator.data:
+            for item in self.coordinator.data:
+                if item.get("code") == COOLING_FUNCTION_CODE:
+                    return item.get("value")
+        return None
+
+    async def _set_power(self, turn_on: bool) -> None:
+        """Write H05 instead of Power."""
+        device_code = (self.coordinator.device_info or {}).get("device_code")
+        if not device_code:
+            LOGGER.error("WarmLink: No device_code available, cannot set cooling function")
+            return
+        value = "1" if turn_on else "0"
+        LOGGER.info(f"WarmLink: Requesting cooling function H05={value}")
+        await self.coordinator.api.set_value(device_code, COOLING_FUNCTION_CODE, value)
+        await self.coordinator.async_request_refresh()

--- a/custom_components/warmlink/translations/sensor_da.json
+++ b/custom_components/warmlink/translations/sensor_da.json
@@ -389,5 +389,14 @@
   "Fault3": "Fejlkode 3",
   "Fault4": "Fejlkode 4",
   "Fault7": "Fejlkode 7",
-  "Fault8": "Fejlkode 8"
+  "Fault8": "Fejlkode 8",
+  "T1": "Rumtemperatur",
+  "Fan_Speed_Setting": "Varmeniveau",
+  "2013": "Effektforbrug",
+  "O2": "Tilstand O2",
+  "O5": "Tilstand O5",
+  "H06": "Tilstand H06",
+  "Power_Timer": "Timer",
+  "Power_Timer_Hours": "Timer-timer",
+  "Sleep": "Sovetilstand"
 }

--- a/custom_components/warmlink/translations/sensor_en.json
+++ b/custom_components/warmlink/translations/sensor_en.json
@@ -389,5 +389,14 @@
   "Fault3": "Fault Code 3",
   "Fault4": "Fault Code 4",
   "Fault7": "Fault Code 7",
-  "Fault8": "Fault Code 8"
+  "Fault8": "Fault Code 8",
+  "T1": "Current Temperature",
+  "Fan_Speed_Setting": "Heat Level",
+  "2013": "Power Draw",
+  "O2": "State O2",
+  "O5": "State O5",
+  "H06": "State H06",
+  "Power_Timer": "Power Timer",
+  "Power_Timer_Hours": "Power Timer Hours",
+  "Sleep": "Sleep Mode"
 }

--- a/custom_components/warmlink/units.json
+++ b/custom_components/warmlink/units.json
@@ -72,5 +72,7 @@
   "Zone 2 Mixing Temp": "°C", "Zone 2 Water Target": "°C",
 
   "Power": "W",
-  "compensate_offset": "°C"
+  "compensate_offset": "°C",
+
+  "T1": "°C", "2013": "kW"
 }


### PR DESCRIPTION
Hi @srbjessen — first off, thanks for ha-warmlink! It carried us all the way to getting three Scantherm LT smart radiators (LinkedGo fan coils, productId `1473911871244337152` — already in your PRODUCT_IDS list) fully working in Home Assistant. This PR contributes that work back.

## What it adds

- **productId-based routing** (`const.py`, `coordinator.py`): radiators speak an 18-code protocol, not the 391-code heat-pump one. When the productId matches `RADIATOR_PRODUCT_IDS`, the coordinator polls the lean `RADIATOR_CODES` list instead. Heat pumps are untouched — without a radiator productId every code path is identical to today.
- **Climate entity for radiators** (`climate.py`, new): target temp, current temp (T1), heat level 1–6 as fan modes, and the full mode enum as real HVAC modes.
- **Mode enum, hardware-verified** on real LT-8500-V panels (LED/display observation during a controlled sweep): `0`=auto, `1`=cooling, `2`=dehumidify ("dEH" on the display), `3`=fan-only, `4`=heating; `5` is rejected by the device. The panel's SET TEMP follows the active mode — **R02 in heating, R03 in cooling** — and the climate entity mirrors that, so HA always matches the physical display.
- **One shared API client per account** (`coordinator.py`, `warmlink_api.py`): we verified empirically that the cloud allows only ONE active token per account — a fresh login invalidates the previous token (old token → `-100`). Multiple config entries on the same account (multi-radiator setups use one entry per `device_code`) would otherwise fight over the session. Logins are serialised with an asyncio.Lock. This also benefits heat-pump users who run the app alongside HA.
- **Honest `hvac_action`**: code `2013` turned out to read a constant 1.2 regardless of activity (rated value?) — activity is now detected via `O2` (~1600 while the fan actually spins, 0 at rest).
- **Optimistic pending mode** so a `set_temperature` right after a mode switch targets the correct register instead of racing the 120 s poll.
- **Cooling-function switch (H05)** as a deliberate separate entity rather than auto-enabling cooling (hydronic fan coils + uninsulated pipes = condensation risk; enabling cooling should be an explicit act). Entity name is currently Danish ("Kølefunktion") — happy to localize properly if you prefer.
- Config-flow entry titles include the device code so multi-device accounts can tell entries apart; additive units/translation entries for the radiator codes.

## Verified / not verified

Verified end-to-end on real hardware (owner at the physical panel): read path (panel → HA), write path (R02/R03/Mode/Power/Fan with readback + physical display confirmation), the full mode enum, fan-only actually spinning the fan (O2 readback). Not yet verified: a real heating season with hot water in the loop (it's August), long-term stability beyond a day, and physical cooling (deliberately untested pending pipe insulation).

## Relation to #19

This overlaps in spirit with #19 (climate entities + cooling for heat pumps) — the two could complement each other nicely; the R02/R03 mode-follows-setpoint behavior we verified on radiators may be useful evidence there too.

No breaking changes intended for existing heat-pump users. Happy to adjust anything to fit the project's direction — and thanks again for the solid foundation.

Greetings from Denmark,
Kristian (& his AI pair programmer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)